### PR TITLE
[FLINK-29205]: Kinesis connector was upgraded and contains the fix from FLINK-29205

### DIFF
--- a/EfoConsumer/pom.xml
+++ b/EfoConsumer/pom.xml
@@ -31,12 +31,12 @@
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-kinesis</artifactId>
-            <version>${flink.version}</version>
+            <version>1.15.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-aws-kinesis-streams</artifactId>
-            <version>${flink.version}</version>
+            <version>1.15.3</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
Kinesis connector was upgraded to version 1.15.3. It contains following fixes now:
- [FLINK-29205](https://issues.apache.org/jira/browse/FLINK-29205) - for Credential Provider configuration;
- [FLINK-29324](https://issues.apache.org/jira/browse/FLINK-29324) - for Kinesis connector close method issue.