### PR TITLE
Example of AVRO + Glue Schema Registry with Kafka source and sink

### DIFF
--- a/AvroGlueSchemaRegistryKafka/README.md
+++ b/AvroGlueSchemaRegistryKafka/README.md
@@ -1,0 +1,73 @@
+# AVRO serialization in KafkaSource and KafkaSink using AWS Glue Schema Registry
+
+This example demonstrates how to serialize/deserialize AVRO messages in Kafka sources and sinks, using 
+[AWS Glue Schema Registry](https://docs.aws.amazon.com/glue/latest/dg/schema-registry.html).
+
+This example uses AVRO generated classes (more details, [below](#Using_AVRO-generated_classes))
+
+The reader's schema definition, for the source, and the writer's schema definition, for the sink, are provided as 
+AVRO IDL (`.avdl`) in [./src/main/resources/avro](./src/main/resources/avro).
+
+
+A KafkaSource produces a stream of AVRO data objects (SpecificRecords), fetching the writer's schema from AWS Glue 
+Schema Registry. The AVRO Kafka message value must have been serialized using AWS Glue Schema Registry.
+
+A KafkaSink serializes AVRO data objects as Kafka message value, and a String, converted to bytes as UTF-8, as Kafka 
+message key.
+
+## Flink compatibility
+
+**Note:** This project is compatible with Flink 1.15+ and Kinesis Data Analytics for Apache Flink.
+
+### Flink API compatibility
+
+This example shows how to use AWS Glue Schema Registry with the Flink Java DataStream API.
+
+It uses the newer `KafkaSource` and `KafkaSink` (as opposed to `FlinkKafkaConsumer` and `FlinkKafkaProducer`, deprecated 
+with Flink 1.15).
+
+At the moment, no format provider is available for the Table API.
+
+## Notes about using AVRO with Apache Flink
+
+### AVRO-generated classes
+
+This project uses classes generated at built-time as data objects.
+
+As a best practice, only the AVRO schema definitions (IDL `.avdl` files in this case) are included in the project source 
+code. 
+
+AVRO Maven plugin generates the Java classes (source code) at build-time, during the 
+[`generate-source`](https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html) phase.
+
+The generated classes are written into `./target/generated-sources/avro` directory and should **not** be committed with 
+the project source.
+
+This way, the only dependency is on the schema definition file(s).
+If any change is required, the schema file is modified and the AVRO classes are re-generated automatically in the build.
+
+Code generation is supported by all common IDEs like IntelliJ. 
+If your IDE does not see the AVRO classes (`TemperatureSample` and `RoomTemperature`) when you import the project for the 
+first time, you may manually run `mvn generate-sources` once of force source code generation from the IDE.
+
+### AVRO-generated classes (SpecificRecord) in Apache Flink
+
+Using AVRO-generated classes (SpecificRecord) within the flow of the Flink application (between operators) or in the 
+Flink state, has an additional benefit. 
+Flink will [natively and efficiently serialize and deserialize](https://nightlies.apache.org/flink/flink-docs-master/docs/dev/datastream/fault-tolerance/serialization/types_serialization/#pojos) 
+these objects, without risking of falling back to Kryo.
+
+### AVRO and AWS Glue Schema Registry dependencies
+
+The following dependencies related to AVRO and AWS Glue Schema Registry are included (for FLink 1.15.2):
+
+1. `org.apache.flink:flink-avro-glue-schema-registry_2.12:1.15.2` - Support for AWS Glue Schema Registry SerDe
+2. `org.apache.avro:avro:1.10.2` - Overrides AVRO 1.10.0, transitively included.
+
+The project also includes `org.apache.flink:flink-avro:1.15.2`. 
+This is already a transitive dependency from the Glue Schema Registry SerDe and is defined explicitly only for clarity.
+
+Note that we are overriding AVRO 1.10.0 with 1.10.2. 
+This minor version upgrade does not break the internal API, and includes some bug fixes introduced with 
+AVRO [1.10.1](https://github.com/apache/avro/releases/tag/release-1.10.1)
+and [1.10.2](https://github.com/apache/avro/releases/tag/release-1.10.2). 

--- a/AvroGlueSchemaRegistryKafka/pom.xml
+++ b/AvroGlueSchemaRegistryKafka/pom.xml
@@ -1,0 +1,225 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.amazonaws.services.kinesisanalytics</groupId>
+    <artifactId>flink-app</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <target.java.version>11</target.java.version>
+        <maven.compiler.source>${target.java.version}</maven.compiler.source>
+        <main.class>com.amazonaws.services.kinesisanalytics.KdaFlinkStreamingJob</main.class>
+
+        <scala.binary.version>2.12</scala.binary.version>
+        <avro.version>1.10.2</avro.version>
+        <kafka.clients.version>2.8.1</kafka.clients.version>
+
+        <flink.version>1.15.2</flink.version>
+        <kda.connectors.version>2.0.0</kda.connectors.version>
+        <kda.runtime.version>1.2.0</kda.runtime.version>
+        <aws.sdk.version>1.1.6</aws.sdk.version>
+        <aws.sdk.auth.version>2.19.30</aws.sdk.auth.version>
+
+        <slf4j.version>1.7.32</slf4j.version>
+        <log4j.version>2.17.2</log4j.version>
+        <junit.version>5.9.1</junit.version>
+    </properties>
+
+    <dependencies>
+        <!-- Apache Flink dependencies -->
+        <!-- These dependencies are provided, because they should not be packaged into the JAR file. -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-java</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-java</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-clients</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Kinesis Data Analytics -->
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-kinesisanalytics-runtime</artifactId>
+            <version>${kda.runtime.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-kinesisanalytics-flink</artifactId>
+            <version>${kda.connectors.version}</version>
+        </dependency>
+
+        <!-- Flink connectors -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-base</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-kafka</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+
+        <!-- AVRO -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-avro</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>${avro.version}</version>
+        </dependency>
+
+        <!-- Glue Schema Registry -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-avro-glue-schema-registry_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+
+        <!-- IAM (e.g. for MSK IAM auth -->
+        <!--
+                <dependency>
+                    <groupId>software.amazon.msk</groupId>
+                    <artifactId>aws-msk-iam-auth</artifactId>
+                    <version>${aws.sdk.version}</version>
+                </dependency>
+        -->
+
+        <!-- Add logging framework, to produce console output when running in the IDE. -->
+        <!-- These dependencies are excluded from the application JAR by default. -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>${project.name}</finalName>
+        <plugins>
+            <!-- Java Compiler -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>${target.java.version}</source>
+                    <target>${target.java.version}</target>
+                    <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                </configuration>
+            </plugin>
+
+            <!-- AVRO source generator -->
+            <plugin>
+                <groupId>org.apache.avro</groupId>
+                <artifactId>avro-maven-plugin</artifactId>
+                <version>${avro.version}</version>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>idl-protocol</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirectory>${project.basedir}/src/main/resources/avro</sourceDirectory>
+                            <testSourceDirectory>${project.basedir}/src/test/resources/avro</testSourceDirectory>
+                            <fieldVisibility>private</fieldVisibility>
+                            <stringType>String</stringType>
+                            <enableDecimalLogicalType>true</enableDecimalLogicalType>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- We use the maven-shade plugin to create a fat jar that contains all necessary dependencies. -->
+            <!-- Change the value of <mainClass>...</mainClass> if your program entry point changes. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.1.1</version>
+                <executions>
+                    <!-- Run shade goal on package phase -->
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>org.apache.flink:force-shading</exclude>
+                                    <exclude>com.google.code.findbugs:jsr305</exclude>
+                                    <exclude>org.slf4j:*</exclude>
+                                    <exclude>org.apache.logging.log4j:*</exclude>
+                                </excludes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <!-- Do not copy the signatures in the META-INF folder.
+                                    Otherwise, this might cause SecurityExceptions when using the JAR. -->
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>${main.class}</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>
+
+</project>

--- a/AvroGlueSchemaRegistryKafka/src/main/java/com/amazonaws/services/kinesisanalytics/KdaFlinkStreamingJob.java
+++ b/AvroGlueSchemaRegistryKafka/src/main/java/com/amazonaws/services/kinesisanalytics/KdaFlinkStreamingJob.java
@@ -1,0 +1,230 @@
+package com.amazonaws.services.kinesisanalytics;
+
+import com.amazonaws.services.kinesisanalytics.avro.RoomTemperature;
+import com.amazonaws.services.kinesisanalytics.avro.TemperatureSample;
+import com.amazonaws.services.kinesisanalytics.domain.RoomAverageTemperatureCalculator;
+import com.amazonaws.services.kinesisanalytics.runtime.KinesisAnalyticsRuntime;
+import com.amazonaws.services.schemaregistry.utils.AWSSchemaRegistryConstants;
+import com.amazonaws.services.schemaregistry.utils.AvroRecordType;
+import org.apache.avro.specific.SpecificRecord;
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.connector.kafka.sink.KafkaRecordSerializationSchema;
+import org.apache.flink.connector.kafka.sink.KafkaSink;
+import org.apache.flink.connector.kafka.source.KafkaSource;
+import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializationSchema;
+import org.apache.flink.formats.avro.glue.schema.registry.GlueSchemaRegistryAvroDeserializationSchema;
+import org.apache.flink.formats.avro.glue.schema.registry.GlueSchemaRegistryAvroSerializationSchema;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.LocalStreamEnvironment;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.util.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Sample Kinesis Data Analytics Flink application.
+ *
+ * It reads from a Kafka topic temperature samples serialized as AVRO using Glue Schema Registry.
+ * It calculates average room temperatures every minute, and publish them to another Kafka topic, again serialized as
+ * AVRO using Glue Schema Registry.
+ */
+public class KdaFlinkStreamingJob {
+    private static final Logger LOGGER = LoggerFactory.getLogger(KdaFlinkStreamingJob.class);
+
+    // Name of the local JSON resource with the application properties in the same format as they are received from the KDA runtime
+    private static final String LOCAL_APPLICATION_PROPERTIES_RESOURCE = "flink-application-properties-dev.json";
+
+    // Names of the configuration group containing the application properties
+    private static final String APPLICATION_CONFIG_GROUP = "FlinkApplicationProperties";
+
+    private static boolean isLocal(StreamExecutionEnvironment env) {
+        return env instanceof LocalStreamEnvironment;
+    }
+
+    /**
+     * Load application properties from KDA runtime or from a local resource, when the environment is local
+     */
+    private static Map<String, Properties> loadApplicationProperties(StreamExecutionEnvironment env) throws IOException {
+        if (isLocal(env)) {
+            LOGGER.info("Loading application properties from '{}'", LOCAL_APPLICATION_PROPERTIES_RESOURCE);
+            return KinesisAnalyticsRuntime.getApplicationProperties(
+                    KdaFlinkStreamingJob.class.getClassLoader()
+                            .getResource(LOCAL_APPLICATION_PROPERTIES_RESOURCE).getPath());
+        } else {
+            LOGGER.info("Loading application properties from KDA");
+            return KinesisAnalyticsRuntime.getApplicationProperties();
+        }
+    }
+
+    /**
+     * KafkaSource for any AVRO-generated class (SpecificRecord) using AWS Glue Schema Registry.
+     *
+     * @param <T>                  record type
+     * @param payloadAvroClass     AVRO-generated class for the message body
+     * @param bootstrapServers     Kafka bootstrap server
+     * @param topic                topic name
+     * @param consumerGroupId      Kafka Consumer Group ID
+     * @param schemaRegistryName   Glue Schema Registry name
+     * @param schemaRegistryRegion Glue Schema Registry region
+     * @param kafkaConsumerConfig  configuration passed to the Kafka Consumer
+     * @return a KafkaSource instance
+     */
+    private static <T extends SpecificRecord> KafkaSource<T> kafkaSource(
+            Class<T> payloadAvroClass,
+            String bootstrapServers,
+            String topic,
+            String consumerGroupId,
+            String schemaRegistryName,
+            String schemaRegistryRegion,
+            Properties kafkaConsumerConfig) {
+
+        // DeserializationSchema for the message body: AVRO specific record, with Glue Schema Registry
+        Map<String, Object> deserializerConfig = Map.of(
+                AWSSchemaRegistryConstants.AVRO_RECORD_TYPE, AvroRecordType.SPECIFIC_RECORD.getName(),
+                AWSSchemaRegistryConstants.AWS_REGION, schemaRegistryRegion,
+                AWSSchemaRegistryConstants.REGISTRY_NAME, schemaRegistryName);
+        DeserializationSchema<T> legacyDeserializationSchema = GlueSchemaRegistryAvroDeserializationSchema.forSpecific(payloadAvroClass, deserializerConfig);
+        KafkaRecordDeserializationSchema<T> kafkaRecordDeserializationSchema = KafkaRecordDeserializationSchema.valueOnly(legacyDeserializationSchema);
+
+        // ... more Kafka consumer configurations (e.g. MSK IAM auth) go here...
+
+        return KafkaSource.<T>builder()
+                .setBootstrapServers(bootstrapServers)
+                .setTopics(topic)
+                .setGroupId(consumerGroupId)
+                .setDeserializer(kafkaRecordDeserializationSchema)
+                .setProperties(kafkaConsumerConfig)
+                .build();
+    }
+
+    /**
+     * KafkaSink for any AVRO-generated class (specific records) using AWS Glue Schema Registry
+     * using a Kafka message key (a String) extracted from the record using a KeySelector.
+     *
+     * @param <T>                  record type
+     * @param payloadAvroClass     AVRO-generated class for the message body
+     * @param messageKeyExtractor  KeySelector to extract the message key from the record
+     * @param bootstrapServers     Kafka bootstrap servers
+     * @param topic                topic name
+     * @param schemaRegistryName   Glue Schema Registry name
+     * @param schemaRegistryRegion Glue Schema Registry region
+     * @param kafkaProducerConfig  configuration passed to the Kafka Producer
+     * @return a KafkaSink
+     */
+    private static <T extends SpecificRecord> KafkaSink<T> keyedKafkaSink(
+            Class<T> payloadAvroClass,
+            KeySelector<T, String> messageKeyExtractor,
+            String bootstrapServers,
+            String topic,
+            String schemaRegistryName,
+            String schemaRegistryRegion,
+            Properties kafkaProducerConfig) {
+
+        // SerializationSchema for the message body: AVRO with Glue Schema Registry
+        // (GlueSchemaRegistryAvroSerializationSchema expects a Map<String,Object> as configuration)
+        Map<String, Object> serializerConfig = Map.of(
+                AWSSchemaRegistryConstants.SCHEMA_AUTO_REGISTRATION_SETTING, true, // Enable Schema Auto-registration (the name of the schema is based on the name of the topic)
+                AWSSchemaRegistryConstants.AWS_REGION, schemaRegistryRegion,
+                AWSSchemaRegistryConstants.REGISTRY_NAME, schemaRegistryName);
+        SerializationSchema<T> valueSerializationSchema = GlueSchemaRegistryAvroSerializationSchema.forSpecific(payloadAvroClass, topic, serializerConfig);
+
+        // SerializationSchema for the message key.
+        // Extracts the key (a String) from the record using a KeySelector
+        // and covert the String to bytes as UTF-8 (same default behaviour of org.apache.flink.api.common.serialization.SimpleStringSchema)
+        SerializationSchema<T> keySerializationSchema = record -> {
+            try {
+                return messageKeyExtractor.getKey(record).getBytes(StandardCharsets.UTF_8);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        // ... more Kafka consumer configurations (e.g. MSK IAM auth) go here...
+
+        return KafkaSink.<T>builder()
+                .setBootstrapServers(bootstrapServers)
+                .setRecordSerializer(
+                        KafkaRecordSerializationSchema.builder()
+                                .setTopic(topic)
+                                .setValueSerializationSchema(valueSerializationSchema)
+                                .setKeySerializationSchema(keySerializationSchema)
+                                .build())
+                .setKafkaProducerConfig(kafkaProducerConfig)
+                .build();
+    }
+
+
+    public static void main(String[] args) throws Exception {
+        // set up the streaming execution environment
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setRuntimeMode(RuntimeExecutionMode.STREAMING);
+
+        // Local dev specific settings
+        if (isLocal(env)) {
+            // Checkpointing and parallelism are set by KDA when running on AWS
+            env.enableCheckpointing(60000);
+            env.setParallelism(2);
+        }
+
+        // Application configuration
+        Properties applicationProperties = loadApplicationProperties(env).get(APPLICATION_CONFIG_GROUP);
+        String bootstrapServers = Preconditions.checkNotNull(applicationProperties.getProperty("bootstrap.servers"), "bootstrap.servers not defined");
+        String sourceTopic = Preconditions.checkNotNull(applicationProperties.getProperty("source.topic"), "source.topic not defined");
+        String sourceConsumerGroupId = applicationProperties.getProperty("source.consumer.group.id", "flink-avro-gsr-sample");
+        String sinkTopic = Preconditions.checkNotNull(applicationProperties.getProperty("sink.topic"), "sink.topic not defined");
+        String schemaRegistryName = Preconditions.checkNotNull(applicationProperties.getProperty("schema.registry.name"), "schema.registry.name not defined");
+        String schemaRegistryRegion = Preconditions.checkNotNull(applicationProperties.getProperty("schema.registry.region"), "schema.registry.region not defined");
+
+
+        KafkaSource<TemperatureSample> source = kafkaSource(
+                TemperatureSample.class,
+                bootstrapServers,
+                sourceTopic,
+                sourceConsumerGroupId,
+                schemaRegistryName,
+                schemaRegistryRegion,
+                new Properties() // ...any other Kafka consumer property
+        );
+
+        KafkaSink<RoomTemperature> sink = keyedKafkaSink(
+                RoomTemperature.class,
+                RoomTemperature::getRoom,
+                bootstrapServers,
+                sinkTopic,
+                schemaRegistryName,
+                schemaRegistryRegion,
+                new Properties() // ...any other Kafka producer property
+        );
+
+
+        DataStream<TemperatureSample> temperatureSamples = env.fromSource(
+                        source,
+                        WatermarkStrategy.<TemperatureSample>forBoundedOutOfOrderness(Duration.ofSeconds(10))
+                                .withIdleness(Duration.ofSeconds(60))
+                                .withTimestampAssigner((sample, ts) -> sample.getSampleTime().toEpochMilli()),
+                        "Temperature Samples source")
+                .uid("temperature-samples-source");
+
+        DataStream<RoomTemperature> roomTemperatures = temperatureSamples
+                .keyBy(TemperatureSample::getRoom)
+                .window(TumblingEventTimeWindows.of(Time.seconds(60)))
+                .aggregate(new RoomAverageTemperatureCalculator())
+                .uid("room-temperatures");
+
+        roomTemperatures.sinkTo(sink).uid("room-temperatures-sink");
+
+        env.execute("Flink app");
+    }
+}

--- a/AvroGlueSchemaRegistryKafka/src/main/java/com/amazonaws/services/kinesisanalytics/domain/RoomAverageTemperatureCalculator.java
+++ b/AvroGlueSchemaRegistryKafka/src/main/java/com/amazonaws/services/kinesisanalytics/domain/RoomAverageTemperatureCalculator.java
@@ -1,0 +1,59 @@
+package com.amazonaws.services.kinesisanalytics.domain;
+
+import com.amazonaws.services.kinesisanalytics.avro.RoomTemperature;
+import com.amazonaws.services.kinesisanalytics.avro.TemperatureSample;
+import org.apache.flink.api.common.functions.AggregateFunction;
+
+import java.time.Instant;
+
+/**
+ * AggregateFunction aggregating the room average temperature
+ * (provided only for completeness, but not relevant for the AVRO-Glue Schema Registry example)
+ */
+public class RoomAverageTemperatureCalculator implements AggregateFunction<TemperatureSample, RoomTemperature, RoomTemperature> {
+    private Instant maxInstant(Instant a, Instant b) {
+        return Instant.ofEpochMilli(
+                Math.max(a.toEpochMilli(), b.toEpochMilli()));
+    }
+
+    @Override
+    public RoomTemperature createAccumulator() {
+        return RoomTemperature.newBuilder()
+                .setRoom("").setSampleCount(0).setLastSampleTime(Instant.EPOCH).setTemperature(0).build();
+    }
+
+    @Override
+    public RoomTemperature add(TemperatureSample sample, RoomTemperature accumulator) {
+        final int sampleCount = accumulator.getSampleCount();
+        final float roomAvgTemp = accumulator.getTemperature();
+        final Instant lastSampleTime = maxInstant(accumulator.getLastSampleTime(), sample.getSampleTime());
+        final float newRoomAvgTemp = (roomAvgTemp * sampleCount + sample.getTemperature()) / (float) (sampleCount + 1);
+
+        accumulator.setRoom(sample.getRoom());
+        accumulator.setSampleCount(sampleCount + 1);
+        accumulator.setTemperature(newRoomAvgTemp);
+        accumulator.setLastSampleTime(lastSampleTime);
+
+        return accumulator;
+    }
+
+    @Override
+    public RoomTemperature getResult(RoomTemperature accumulator) {
+        return accumulator;
+    }
+
+    @Override
+    public RoomTemperature merge(RoomTemperature a, RoomTemperature b) {
+        final int totalSampleCount = a.getSampleCount() + b.getSampleCount();
+        final float avgTemperature = (a.getTemperature() * a.getSampleCount() + b.getTemperature() * b.getSampleCount()) / (float) (totalSampleCount);
+
+        return RoomTemperature.newBuilder()
+                .setRoom(a.getRoom())
+                .setSampleCount(totalSampleCount)
+                .setTemperature(avgTemperature)
+                .setLastSampleTime(maxInstant(a.getLastSampleTime(), b.getLastSampleTime()))
+                .build();
+    }
+
+
+}

--- a/AvroGlueSchemaRegistryKafka/src/main/resources/avro/input-reader-schema.avdl
+++ b/AvroGlueSchemaRegistryKafka/src/main/resources/avro/input-reader-schema.avdl
@@ -1,0 +1,9 @@
+@namespace("com.amazonaws.services.kinesisanalytics.avro")
+protocol In {
+	record TemperatureSample {
+		int sensorId;
+		string room;
+		float temperature;
+		timestamp_ms sampleTime;
+	}
+}

--- a/AvroGlueSchemaRegistryKafka/src/main/resources/avro/output-writer-schema.avdl
+++ b/AvroGlueSchemaRegistryKafka/src/main/resources/avro/output-writer-schema.avdl
@@ -1,0 +1,9 @@
+@namespace("com.amazonaws.services.kinesisanalytics.avro")
+protocol Out {
+	record RoomTemperature {
+		string room;
+		float temperature;
+		int sampleCount;
+		timestamp_ms lastSampleTime;
+	}
+}

--- a/AvroGlueSchemaRegistryKafka/src/main/resources/flink-application-properties-dev.json
+++ b/AvroGlueSchemaRegistryKafka/src/main/resources/flink-application-properties-dev.json
@@ -1,0 +1,13 @@
+[
+  {
+    "PropertyGroupId": "FlinkApplicationProperties",
+    "PropertyMap": {
+      "bootstrap.servers": "localhost:29092",
+      "source.topic": "temperature-samples",
+      "source.consumer.group.id": "flink-avro-gsr",
+      "sink.topic": "room-temperatures",
+      "schema.registry.name": "avro-sample",
+      "schema.registry.region": "eu-west-1"
+    }
+  }
+]

--- a/AvroGlueSchemaRegistryKafka/src/main/resources/log4j2.properties
+++ b/AvroGlueSchemaRegistryKafka/src/main/resources/log4j2.properties
@@ -1,0 +1,7 @@
+appender.console.name = ConsoleAppender
+appender.console.type = CONSOLE
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+
+rootLogger.level = INFO
+rootLogger.appenderRef.console.ref = ConsoleAppender

--- a/AvroGlueSchemaRegistryKafka/src/test/java/com/amazonaws/services/kinesisanalytics/domain/RoomAverageTemperatureCalculatorTest.java
+++ b/AvroGlueSchemaRegistryKafka/src/test/java/com/amazonaws/services/kinesisanalytics/domain/RoomAverageTemperatureCalculatorTest.java
@@ -1,0 +1,86 @@
+package com.amazonaws.services.kinesisanalytics.domain;
+
+import com.amazonaws.services.kinesisanalytics.avro.RoomTemperature;
+import com.amazonaws.services.kinesisanalytics.avro.TemperatureSample;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class RoomAverageTemperatureCalculatorTest {
+
+    RoomAverageTemperatureCalculator sut = new RoomAverageTemperatureCalculator();
+
+    @Test
+    void createAccumulator() {
+        RoomTemperature roomTemperature = sut.createAccumulator();
+
+        assertNotNull(roomTemperature);
+        assertEquals(0.0f, roomTemperature.getTemperature());
+        assertEquals(0, roomTemperature.getSampleCount());
+        assertEquals(Instant.EPOCH, roomTemperature.getLastSampleTime());
+    }
+
+    @Test
+    void add() {
+        TemperatureSample sample = TemperatureSample.newBuilder()
+                .setSensorId(42)
+                .setRoom("a-room")
+                .setSampleTime(Instant.ofEpochMilli(50))
+                .setTemperature(10.0f)
+                .build();
+        RoomTemperature acc = RoomTemperature.newBuilder()
+                .setRoom("a-room")
+                .setSampleCount(10)
+                .setTemperature(20.0f)
+                .setLastSampleTime(Instant.ofEpochMilli(100))
+                .build();
+
+        RoomTemperature accOut = sut.add(sample, acc);
+
+        assertEquals("a-room", accOut.getRoom());
+        assertEquals(10 + 1, accOut.getSampleCount());
+        assertEquals(Instant.ofEpochMilli(100), accOut.getLastSampleTime());
+        assertEquals((20.0f * 10 + 10.0f) / (float) (10 + 1), accOut.getTemperature());
+    }
+
+    @Test
+    void getResult() {
+        RoomTemperature acc = RoomTemperature.newBuilder()
+                .setRoom("a-room")
+                .setSampleCount(10)
+                .setTemperature(20.0f)
+                .setLastSampleTime(Instant.ofEpochMilli(100))
+                .build();
+
+        RoomTemperature result = sut.getResult(acc);
+        assertEquals(acc.getRoom(), result.getRoom());
+        assertEquals(acc.getTemperature(), result.getTemperature());
+        assertEquals(acc.getSampleCount(), result.getSampleCount());
+        assertEquals(acc.getLastSampleTime(), acc.getLastSampleTime());
+    }
+
+    @Test
+    void merge() {
+        RoomTemperature a = RoomTemperature.newBuilder()
+                .setRoom("a-room")
+                .setSampleCount(10)
+                .setTemperature(20.0f)
+                .setLastSampleTime(Instant.ofEpochMilli(100))
+                .build();
+        RoomTemperature b = RoomTemperature.newBuilder()
+                .setRoom("a-room")
+                .setSampleCount(20)
+                .setTemperature(40.0f)
+                .setLastSampleTime(Instant.ofEpochMilli(200))
+                .build();
+
+        RoomTemperature c = sut.merge(a, b);
+        assertEquals("a-room", c.getRoom());
+        assertEquals(10 + 20, c.getSampleCount());
+        assertEquals((20.0f * 10 + 40.0f * 20) / (float) (10 + 20), c.getTemperature());
+        assertEquals(Instant.ofEpochMilli(200), c.getLastSampleTime());
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Example of Flink application using AVRO with AWS Glue Schema Registry, for Kafka source and sink.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
