### PR TITLE
Flip format from CSV to JSON to bypass Flink issue FLINK-28513

### DIFF
--- a/python/S3Sink/streaming-file-sink.py
+++ b/python/S3Sink/streaming-file-sink.py
@@ -95,7 +95,7 @@ def create_sink_table(table_name, bucket_name):
               WITH (
                   'connector'='filesystem',
                   'path'='s3a://{1}/',
-                  'format'='csv',
+                  'format'='json',
                   'sink.partition-commit.policy.kind'='success-file',
                   'sink.partition-commit.delay' = '1 min'
               ) """.format(table_name, bucket_name)


### PR DESCRIPTION
There is a bug in Flink which results in this sample app not working with the CVS format. Flipping from CSV to JSON to workaround the issue:
- https://issues.apache.org/jira/browse/FLINK-28513